### PR TITLE
Update MvcPager.js

### DIFF
--- a/MvcPager/MvcPager.js
+++ b/MvcPager/MvcPager.js
@@ -102,6 +102,7 @@ Webdiyer.MvcPager.prototype = {
             { this.__ajax(hashIndex, { type: this.httpMethod, data: [] }); }
             if (typeof this.dataFormId !== "undefined") {
                 var isAjaxForm = $(context.dataFormId).data("ajax") || false;
+                context.searchCriteria = $(context.dataFormId).serializeArray();
                 $(context.dataFormId).submit(function (event) {
                     context.searchCriteria = $(context.dataFormId).serializeArray();
                     if (isAjaxForm) {


### PR DESCRIPTION
在开启dataFormId时应该给searchCriteria赋值，否则Action若使用了ValidateAntiForgeryTokenAttribute或者Form里带有其它初始Hidden值时，在第一次加载页面后需要Form有一次Submit，searchCriteria才会有值，才可以在Pagination点击，否则post的数据不正确
