### PR TITLE
ajaxform 模式下,输入或选择页bug修复

### DIFF
--- a/MvcPager/MvcPager.js
+++ b/MvcPager/MvcPager.js
@@ -148,6 +148,24 @@ Webdiyer.MvcPager.prototype = {
                     context.__ajax(newPageIndex, { type: context.httpMethod, data: [] });
                 }
             });
+			/**
+			* 在指定的数据表单id后, 检测更新区域是否发生变化
+			* 测试阶段使用了 DOMNodeInserted 事件, 为了浏览器兼容性, 使用了window.setInterval来做检测.
+			*/
+			var _this = this;
+			$(_this.dataFormId).submit(function () {
+				if (!_this.updateTarget || $(_this.updateTarget).length == 0) return;
+				var oldHtml = $(_this.updateTarget).html();
+				var listenUpdateTarget = window.setInterval(function () {
+					if (oldHtml != $(_this.updateTarget).html()) {
+						window.clearInterval(listenUpdateTarget);
+						//更新总页码数据
+						var _wrapper = $(_this.updateTarget).find("[data-pagerid='Webdiyer.MvcPager']:first");
+						_this.pageCount = _wrapper.data("pagecount");
+						_this.__fillPageIndexBox();
+					}
+				});
+			})
         }
         //page index box
         this.__bindPageIndexBox();
@@ -167,7 +185,7 @@ Webdiyer.MvcPager.prototype = {
                             context.__validateInput(event);
                         });
                     }
-                    if ($.trim(context.goToButton) !== "") {
+                    if ($.trim(context.goToButton) !== "" && $(context.goToButton).length > 0) {
                         $(context.updateTarget).on("click", context.goToButton, function () {
                             var newPageIndex = $(context.pageIndexBox).val();
                             context.goToPage(newPageIndex);
@@ -199,7 +217,7 @@ Webdiyer.MvcPager.prototype = {
                 context.__validateInput(event);
             });
         }
-        if ($.trim(context.goToButton) !== "") {
+        if ($.trim(context.goToButton) !== "" && $(context.goToButton).length > 0) {
             $(context.goToButton).click(function () {
                 var newPageIndex = $(context.pageIndexBox).val();
                 context.goToPage(newPageIndex);


### PR DESCRIPTION
1,修复ajaxform 模式下, 如果通过表单改变了搜索结果的情况下, 原pagerIndexID对应的元素无法获取分页数据的bug.
2,增加goToButton对应功能的兼容性, 如果id指定元素不存在,则pagerIndexID对应的元素的change事件依然生效